### PR TITLE
Treat a null value as maskable

### DIFF
--- a/src/mask-deep.js
+++ b/src/mask-deep.js
@@ -28,6 +28,7 @@ const shouldBeEmptyString = (key, maskTimePropsNormally) =>
 
 const isMaskable = (value) => {
   const type = typeof value;
+  if (value === null) return true;
   return (value instanceof Date) || (type !== 'object' && type !== 'function');
 };
 

--- a/test/mask-deep.test.js
+++ b/test/mask-deep.test.js
@@ -93,4 +93,8 @@ describe('mask deep', () => {
     assert.deepEqual(maskDeep('a string', ['a', 'b']), 'a string');
     assert.deepEqual(maskDeep(1, []), 1);
   });
+
+  it('should treat a null value as maskable', () => {
+    assert.deepEqual(maskDeep({ a: null }, ['a']), { a: '***l' });
+  });
 });


### PR DESCRIPTION
This permits a `null` value to be masked (as '***l') based on similar behaviour with `undefined` values. `typeof x` will return `'object'` when `x` is `null`, and I think this was unintended behaviour in `isMaskable`. Calling `mapValues(null, (x) => x)` will return `{}`.

This leads to a nasty bug with Elasticsearch and Kibana. If Elasticsearch is drawing up its field mappings, it will use the first document it gets with that field to determine the type it expects in that field. We had a situation where a service was outputting `null` values and string values to a field, but the first document indexed by Elasticsearch had an object there due to this behaviour. Subsequent documents with string values in this field then caused an error that prevented the messages from appearing in the logs.