### PR TITLE
Make isMaskable something that can be configured by the consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Masks the values of the provided keys within an object (recursively) or within a
   - `percentage` [integer] - how much of each property to mask. Should be an integer between 0 and 100 (inclusive). Defaults to `80`
   - `maskFromRight` [boolean] - mask values starting from the right, e.g. `'mask-this'` becomes `'ma*******'`. Defaults to `false`
   - `maskTimePropsNormally` [boolean] - see 'Time props' note below. Defaults to `false`
+  - `isMaskable` [function(value)] - a callback to check if a value should be masked. Should return `true|false`.
 
 ### Important notes about behaviour
 #### Properties that are arrays or objects

--- a/src/mask-deep.js
+++ b/src/mask-deep.js
@@ -75,7 +75,12 @@ const qsMask = (value, keysToMask, options) => {
 const maskDeep = (source, key, keysToMask, options) => {
   if (options.isMaskable(source)) return maskPrimitive(source, key, options);
   if (Array.isArray(source)) return source.map((value, idx) => maskDeep(value, idx, keysToMask, options));
-  return mapValues(source, (value, _key) => maskDeep(value, _key, keysToMask, options));
+
+  if (isPlainObject(source)) {
+    return mapValues(source, (value, _key) => maskDeep(value, _key, keysToMask, options));
+  }
+
+  return source;
 };
 
 const findAndMask = (source, keysToMask, options = {}) => {

--- a/src/mask-deep.js
+++ b/src/mask-deep.js
@@ -6,6 +6,11 @@ const defaultOptions = {
   percentage: 80,
   maskTimePropsNormally: false,
   maskFromRight: false,
+  isMaskable(value) {
+    const type = typeof value;
+    if (value === null) return true;
+    return (value instanceof Date) || (type !== 'object' && type !== 'function');
+  }
 };
 
 const checkOptions = (options) => {
@@ -25,12 +30,6 @@ const checkOptions = (options) => {
 
 const shouldBeEmptyString = (key, maskTimePropsNormally) =>
   ['date', 'time'].some(word => String(key).toLowerCase().includes(word)) && !maskTimePropsNormally;
-
-const isMaskable = (value) => {
-  const type = typeof value;
-  if (value === null) return true;
-  return (value instanceof Date) || (type !== 'object' && type !== 'function');
-};
 
 const maskPrimitive = (value, key, options) => {
   const { percentage, maskTimePropsNormally, maskFromRight } = options;
@@ -74,7 +73,7 @@ const qsMask = (value, keysToMask, options) => {
 };
 
 const maskDeep = (source, key, keysToMask, options) => {
-  if (isMaskable(source)) return maskPrimitive(source, key, options);
+  if (options.isMaskable(source)) return maskPrimitive(source, key, options);
   if (Array.isArray(source)) return source.map((value, idx) => maskDeep(value, idx, keysToMask, options));
   return mapValues(source, (value, _key) => maskDeep(value, _key, keysToMask, options));
 };
@@ -85,7 +84,7 @@ const findAndMask = (source, keysToMask, options = {}) => {
 
   const topLevelQsMaskResult = qsMask(source, keysToMask, finalOptions);
   if (topLevelQsMaskResult) return topLevelQsMaskResult;
-  if (isMaskable(source)) return source; // source is url with no offending query props or it's just stringlike - so we're just returning it.
+  if (finalOptions.isMaskable(source)) return source; // source is url with no offending query props or it's just stringlike - so we're just returning it.
 
   const propertyHandler = (value, key) => {
     const qsMaskResult = qsMask(value, keysToMask, finalOptions);

--- a/test/mask-deep.test.js
+++ b/test/mask-deep.test.js
@@ -97,4 +97,14 @@ describe('mask deep', () => {
   it('should treat a null value as maskable', () => {
     assert.deepEqual(maskDeep({ a: null }, ['a']), { a: '***l' });
   });
+
+  it('should allow overriding isMaskable check', () => {
+    const onlyStrings = (value) => typeof value === 'string';
+
+    assert.deepEqual(maskDeep({ a: 'string' }, ['a'], { isMaskable: onlyStrings }), { a: '*****g' });
+    assert.deepEqual(maskDeep({ a: ['array'] }, ['a'], { isMaskable: onlyStrings }), { a: ['****y'] });
+    assert.deepEqual(maskDeep({ a: 12345 }, ['a'], { isMaskable: onlyStrings }), { a: 12345 });
+    assert.deepEqual(maskDeep({ a: null }, ['a'], { isMaskable: onlyStrings }), { a: null });
+    assert.deepEqual(maskDeep({ a: undefined }, ['a'], { isMaskable: onlyStrings }), { a: undefined });
+  });
 });


### PR DESCRIPTION
This PR will allow users to override the internal `isMaskable` logic to better fit their usage profile.